### PR TITLE
Add backwards compatible overload to VerificationRequester

### DIFF
--- a/v2client/src/main/java/com/yubico/client/v2/VerificationRequester.java
+++ b/v2client/src/main/java/com/yubico/client/v2/VerificationRequester.java
@@ -69,6 +69,16 @@ public class VerificationRequester {
 	}
 
 	/**
+	 * Alias of <code>fetch(urls, userAgent, 5)</code>.
+	 * @deprecated Use {@link #fetch(List, String, int)} with an explicit
+	 * <code>maxRetries</code> argument instead.
+	 */
+	@Deprecated
+	public VerificationResponse fetch(List<String> urls, String userAgent) throws YubicoVerificationException {
+		return fetch(urls, userAgent, 5);
+	}
+
+	/**
 	 * Fires off a validation request to each url in the list, returning the first one
 	 * that is not {@link ResponseStatus#REPLAYED_REQUEST}
 	 * 

--- a/v2client/src/test/java/com/yubico/client/v2/YubicoClientTest.java
+++ b/v2client/src/test/java/com/yubico/client/v2/YubicoClientTest.java
@@ -166,6 +166,7 @@ public class YubicoClientTest {
             private boolean firstCall = true;
 
             @Override
+            @SuppressWarnings("deprecation")
             public VerificationResponse fetch(List<String> urls, String userAgent) throws YubicoVerificationException {
                 // Plain pass-through just to test that the signature is stable
                 return super.fetch(urls, userAgent);

--- a/v2client/src/test/java/com/yubico/client/v2/YubicoClientTest.java
+++ b/v2client/src/test/java/com/yubico/client/v2/YubicoClientTest.java
@@ -8,6 +8,8 @@ import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URL;
+import java.util.List;
+
 import org.junit.Before;
 import org.junit.Test;
 
@@ -162,6 +164,13 @@ public class YubicoClientTest {
 
         YubicoClient client = new TestYubicoClientImpl(new VerificationRequester() {
             private boolean firstCall = true;
+
+            @Override
+            public VerificationResponse fetch(List<String> urls, String userAgent) throws YubicoVerificationException {
+                // Plain pass-through just to test that the signature is stable
+                return super.fetch(urls, userAgent);
+            }
+
             @Override
             protected VerifyTask createTask(String userAgent, String url, int maxRetries) {
                 if (firstCall) {


### PR DESCRIPTION
Since `VerificationRequester` strictly speaking is part of the public API.